### PR TITLE
Updated the help message to include top channel members

### DIFF
--- a/karmabot/controller/karma.py
+++ b/karmabot/controller/karma.py
@@ -413,6 +413,7 @@ class KarmaController(object):
                              "`/karma top groups` - Show the top 10 groups\n"
                              "`/karma top channels` - Show the top 10 channels\n"
                              "`/karma top things` - Show the top 10 things\n"
+                             "`/karma top channel members` - Show the top 10 members of a channel\n"
                              "`/karma stats` - Show some interesting statstics about Karma\n"
                              "`/karma stats thing` - Show some interesting statstics about `thing`\n")
                 }


### PR DESCRIPTION
- What I did
Updated the help message to include **top channel members** command.

- Why I did it
We forgot to include it during our last PR

- How to verify it
payload:{"command": "/karma", "text": "help", "token": "", "team_id": "<team_id>", "user_id": "", "channel_id": "<channel_id>", "event": {"channel": "<channel_id>"}}

- Meme/emoji that summarize this change (not mandatory)
📖 🖊️ 