### PR TITLE
Fix the user regex

### DIFF
--- a/karmabot/regex.py
+++ b/karmabot/regex.py
@@ -30,7 +30,7 @@ squoted3_thing_re = re.compile(r'\u201c(?P<sqthing3>[^\n\u201d]+)\u201d')
 # double low-9/high-rev 9 quote
 squoted4_thing_re = re.compile(r'\u201e(?P<sqthing4>[^\n\u201f]+)\u201f')
 # @anna++ -> <@UABC1234>++ or <@UABC1234|anna>
-user_re = re.compile(r'<@(?P<user>[A-Z_.0-9|]+)(?:\|[^>]+)?>')
+user_re = re.compile(r'<@(?P<user>[A-Z_.0-9]+)(?:\|[^>]+)?>')
 # #beth++ -> <#CDE2345|beth>++
 channel_re = re.compile(r'<#(?P<channel>[A-Z_.0-9]+)\|(?:[^\s]+)>')
 # @charming-admins -> <!subteam^CDE3456|charming-admins>


### PR DESCRIPTION
For explanation:  There was an erroneous `|` in the id matching portion.
Slack sends users in the format of `<@U1234|Bob>` where the pipe delimits
the "human readable fallback" portion.  But users can also be sent as `<@U1234>`

The old regex worked fine with both of these situations, but the extra `|` in the first part of the match should not be there.


